### PR TITLE
manifest: Track own external/libvorbis

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -200,7 +200,7 @@
   <project path="external/libusb-compat" name="platform/external/libusb-compat" groups="pdk" remote="aosp" />
   <project path="external/libutf" name="platform/external/libutf" groups="pdk" remote="aosp" />
   <project path="external/libvncserver" name="platform/external/libvncserver" groups="pdk" remote="aosp" />
-  <project path="external/libvorbis" name="platform/external/libvorbis" groups="pdk" remote="aosp" />
+  <project path="external/libvorbis" name="LineageOS/android_external_libvorbis" groups="pdk" />
   <project path="external/libvpx" name="LineageOS/android_external_libvpx" groups="pdk" />
   <project path="external/libvterm" name="platform/external/libvterm" groups="pdk" remote="aosp" />
   <project path="external/libweave" name="platform/external/libweave" groups="pdk" remote="aosp" />


### PR DESCRIPTION
Google has not published most recent 8.0.1_r33 tag for external/libvorbis
and instead declared the patch for CVE-2018-5146 "non-public".
Hence we need to track our own fork of it.

Change-Id: Ie7007f90ec003da4e6ad8a659fbbfb75ae0ebc6f