### PR TITLE
manifest: Remove external/libvorbis

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -200,7 +200,6 @@
   <project path="external/libusb-compat" name="platform/external/libusb-compat" groups="pdk" remote="aosp" />
   <project path="external/libutf" name="platform/external/libutf" groups="pdk" remote="aosp" />
   <project path="external/libvncserver" name="platform/external/libvncserver" groups="pdk" remote="aosp" />
-  <project path="external/libvorbis" name="LineageOS/android_external_libvorbis" groups="pdk" />
   <project path="external/libvpx" name="LineageOS/android_external_libvpx" groups="pdk" />
   <project path="external/libvterm" name="platform/external/libvterm" groups="pdk" remote="aosp" />
   <project path="external/libweave" name="platform/external/libweave" groups="pdk" remote="aosp" />


### PR DESCRIPTION
* This is actually unused in Android N

Change-Id: I57bce513f9a8f4fc098d20a1ca7b806fb9e6cbe8